### PR TITLE
Implemented wlr screencopy protocol

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,6 +7,7 @@ pub enum CompositorError {
     Renderer(String),
     Socket(std::io::Error),
     EventLoop(String),
+    Screencopy(String),
 }
 
 impl fmt::Display for CompositorError {
@@ -16,6 +17,7 @@ impl fmt::Display for CompositorError {
             Self::Renderer(msg) => write!(f, "renderer creation failed: {msg}"),
             Self::Socket(err) => write!(f, "wayland socket creation failed: {err}"),
             Self::EventLoop(msg) => write!(f, "event loop error: {msg}"),
+            Self::Screencopy(msg) => write!(f, "screencopy failed: {msg}"),
         }
     }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,51 +1,65 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
 use crate::grabs::move_grab::MoveSurfaceGrab;
 use crate::grabs::resize_grab::{self, ResizeSurfaceGrab};
 use crate::state::{ClientState, ProjectWC};
 use smithay::delegate_layer_shell;
 use smithay::delegate_primary_selection;
-use smithay::desktop::{LayerSurface, PopupManager, Space, layer_map_for_output};
+use smithay::desktop::{layer_map_for_output, LayerSurface, PopupManager, Space};
 use smithay::output::Output;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
+use smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::{
+    zwlr_screencopy_frame_v1::{self, Flags, ZwlrScreencopyFrameV1},
+    zwlr_screencopy_manager_v1::{self, ZwlrScreencopyManagerV1},
+};
+use smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer;
 use smithay::reexports::wayland_server::protocol::wl_output::WlOutput;
-use smithay::utils::Rectangle;
+use smithay::reexports::wayland_server::protocol::wl_shm::Format;
+use smithay::reexports::wayland_server::{
+    Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New,
+};
+use smithay::utils::{Physical, Rectangle, Size};
 use smithay::wayland::compositor;
 use smithay::wayland::selection::data_device::set_data_device_focus;
 use smithay::wayland::selection::primary_selection::{
-    PrimarySelectionHandler, PrimarySelectionState, set_primary_focus,
+    set_primary_focus, PrimarySelectionHandler, PrimarySelectionState,
 };
 use smithay::wayland::shell::wlr_layer::{
     Layer, LayerSurface as WlrLayerSurface, LayerSurfaceData, WlrLayerShellHandler,
     WlrLayerShellState,
 };
 use smithay::wayland::shell::xdg::XdgToplevelSurfaceData;
+use smithay::wayland::shm;
 use smithay::{
     backend::renderer::utils::on_commit_buffer_handler,
     delegate_compositor, delegate_data_device, delegate_output, delegate_seat, delegate_shm,
     delegate_xdg_shell,
     desktop::{
-        PopupKind, Window, WindowSurfaceType, find_popup_root_surface, get_popup_toplevel_coords,
+        find_popup_root_surface, get_popup_toplevel_coords, PopupKind, Window, WindowSurfaceType,
     },
     input::{
-        Seat, SeatHandler, SeatState,
         pointer::{CursorImageStatus, Focus, GrabStartData as PointerGrabStartData},
+        Seat, SeatHandler, SeatState,
     },
     reexports::wayland_server::{
-        Resource,
         protocol::{wl_buffer, wl_seat, wl_surface::WlSurface},
+        Resource,
     },
     utils::Serial,
     wayland::{
         buffer::BufferHandler,
         compositor::{
-            CompositorClientState, CompositorHandler, CompositorState, get_parent,
-            is_sync_subsurface,
+            get_parent, is_sync_subsurface, CompositorClientState, CompositorHandler,
+            CompositorState,
         },
         output::OutputHandler,
         selection::{
-            SelectionHandler,
             data_device::{
                 ClientDndGrabHandler, DataDeviceHandler, DataDeviceState, ServerDndGrabHandler,
             },
+            SelectionHandler,
         },
         shell::xdg::{
             PopupSurface, PositionerState, ToplevelSurface, XdgShellHandler, XdgShellState,
@@ -434,3 +448,281 @@ fn handle_commit(popups: &mut PopupManager, space: &Space<Window>, surface: &WlS
         }
     }
 }
+
+const SCREENCOPY_VERSION: u32 = 3;
+
+#[derive(Default)]
+pub struct ScreencopyManagerState;
+
+pub struct ScreencopyManagerGlobalData {
+    filter: Box<dyn for<'c> Fn(&'c Client) -> bool + Send + Sync>,
+}
+
+impl ScreencopyManagerState {
+    pub fn new<D, F>(display: &DisplayHandle, filter: F) -> Self
+    where
+        D: GlobalDispatch<ZwlrScreencopyManagerV1, ScreencopyManagerGlobalData>,
+        D: Dispatch<ZwlrScreencopyManagerV1, ()>,
+        D: Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameState>,
+        D: ScreencopyHandler,
+        D: 'static,
+        F: for<'c> Fn(&'c Client) -> bool + Send + Sync + 'static,
+    {
+        let global_data = ScreencopyManagerGlobalData {
+            filter: Box::new(filter),
+        };
+        display.create_global::<D, ZwlrScreencopyManagerV1, _>(SCREENCOPY_VERSION, global_data);
+
+        Self
+    }
+}
+
+impl<D> GlobalDispatch<ZwlrScreencopyManagerV1, ScreencopyManagerGlobalData, D>
+    for ScreencopyManagerState
+where
+    D: GlobalDispatch<ZwlrScreencopyManagerV1, ScreencopyManagerGlobalData>,
+    D: Dispatch<ZwlrScreencopyManagerV1, ()>,
+    D: Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameState>,
+    D: ScreencopyHandler,
+    D: 'static,
+{
+    fn bind(
+        _state: &mut D,
+        _display: &DisplayHandle,
+        _client: &Client,
+        manager: New<ZwlrScreencopyManagerV1>,
+        _manager_state: &ScreencopyManagerGlobalData,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        data_init.init(manager, ());
+    }
+
+    fn can_view(client: Client, global_data: &ScreencopyManagerGlobalData) -> bool {
+        (global_data.filter)(&client)
+    }
+}
+
+impl<D> Dispatch<ZwlrScreencopyManagerV1, (), D> for ScreencopyManagerState
+where
+    D: GlobalDispatch<ZwlrScreencopyManagerV1, ScreencopyManagerGlobalData>,
+    D: Dispatch<ZwlrScreencopyManagerV1, ()>,
+    D: Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameState>,
+    D: ScreencopyHandler,
+    D: 'static,
+{
+    fn request(
+        _state: &mut D,
+        _client: &Client,
+        _manager: &ZwlrScreencopyManagerV1,
+        request: zwlr_screencopy_manager_v1::Request,
+        _data: &(),
+        _display: &DisplayHandle,
+        data_init: &mut DataInit<'_, D>,
+    ) {
+        let (frame, output) = match request {
+            zwlr_screencopy_manager_v1::Request::CaptureOutput { frame, output, .. } => {
+                let Some(output) = Output::from_resource(&output) else {
+                    tracing::trace!("screencopy: client requested non-existent output");
+                    let frame = data_init.init(frame, ScreencopyFrameState::Failed);
+                    frame.failed();
+                    return;
+                };
+                (frame, output)
+            }
+            // TODO: implement region capture (currently captures full output)
+            zwlr_screencopy_manager_v1::Request::CaptureOutputRegion { frame, output, .. } => {
+                let Some(output) = Output::from_resource(&output) else {
+                    tracing::trace!("screencopy: client requested non-existent output");
+                    let frame = data_init.init(frame, ScreencopyFrameState::Failed);
+                    frame.failed();
+                    return;
+                };
+                (frame, output)
+            }
+            zwlr_screencopy_manager_v1::Request::Destroy => return,
+            _ => unreachable!(),
+        };
+
+        let Some(mode) = output.current_mode() else {
+            tracing::trace!("screencopy: output has no current mode");
+            let frame = data_init.init(frame, ScreencopyFrameState::Failed);
+            frame.failed();
+            return;
+        };
+
+        let buffer_size = mode.size;
+        let info = ScreencopyFrameInfo {
+            output,
+            buffer_size,
+        };
+        let frame = data_init.init(
+            frame,
+            ScreencopyFrameState::Pending {
+                info,
+                copied: Arc::new(AtomicBool::new(false)),
+            },
+        );
+
+        frame.buffer(
+            Format::Xrgb8888,
+            buffer_size.w as u32,
+            buffer_size.h as u32,
+            buffer_size.w as u32 * 4,
+        );
+
+        if frame.version() >= 3 {
+            frame.buffer_done();
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ScreencopyFrameInfo {
+    output: Output,
+    buffer_size: Size<i32, Physical>,
+}
+
+pub enum ScreencopyFrameState {
+    Failed,
+    Pending {
+        info: ScreencopyFrameInfo,
+        copied: Arc<AtomicBool>,
+    },
+}
+
+impl<D> Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameState, D> for ScreencopyManagerState
+where
+    D: Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameState>,
+    D: ScreencopyHandler,
+    D: 'static,
+{
+    fn request(
+        state: &mut D,
+        _client: &Client,
+        frame: &ZwlrScreencopyFrameV1,
+        request: zwlr_screencopy_frame_v1::Request,
+        data: &ScreencopyFrameState,
+        _display: &DisplayHandle,
+        _data_init: &mut DataInit<'_, D>,
+    ) {
+        if matches!(request, zwlr_screencopy_frame_v1::Request::Destroy) {
+            return;
+        }
+
+        let ScreencopyFrameState::Pending { info, copied } = data else {
+            return;
+        };
+
+        if copied.load(Ordering::SeqCst) {
+            frame.post_error(
+                zwlr_screencopy_frame_v1::Error::AlreadyUsed,
+                "copy was already requested",
+            );
+            return;
+        }
+
+        let buffer = match request {
+            zwlr_screencopy_frame_v1::Request::Copy { buffer } => buffer,
+            zwlr_screencopy_frame_v1::Request::CopyWithDamage { buffer } => buffer,
+            _ => unreachable!(),
+        };
+
+        let size = info.buffer_size;
+
+        let valid = shm::with_buffer_contents(&buffer, |_, shm_len, buffer_data| {
+            buffer_data.format == Format::Xrgb8888
+                && buffer_data.width == size.w
+                && buffer_data.height == size.h
+                && buffer_data.stride == size.w * 4
+                && shm_len == buffer_data.stride as usize * buffer_data.height as usize
+        })
+        .unwrap_or(false);
+
+        if !valid {
+            frame.post_error(
+                zwlr_screencopy_frame_v1::Error::InvalidBuffer,
+                "invalid buffer",
+            );
+            return;
+        }
+
+        copied.store(true, Ordering::SeqCst);
+
+        state.frame(Screencopy {
+            buffer,
+            frame: frame.clone(),
+            info: info.clone(),
+            submitted: false,
+        });
+    }
+}
+
+pub struct Screencopy {
+    pub buffer: WlBuffer,
+    frame: ZwlrScreencopyFrameV1,
+    info: ScreencopyFrameInfo,
+    submitted: bool,
+}
+
+impl Drop for Screencopy {
+    fn drop(&mut self) {
+        if !self.submitted {
+            self.frame.failed();
+        }
+    }
+}
+
+impl Screencopy {
+    pub fn output(&self) -> &Output {
+        &self.info.output
+    }
+
+    pub fn buffer_size(&self) -> Size<i32, Physical> {
+        self.info.buffer_size
+    }
+
+    pub fn submit(mut self, timestamp: Duration) {
+        self.frame.flags(Flags::empty());
+
+        let tv_sec_hi = (timestamp.as_secs() >> 32) as u32;
+        let tv_sec_lo = (timestamp.as_secs() & 0xFFFFFFFF) as u32;
+        let tv_nsec = timestamp.subsec_nanos();
+        self.frame.ready(tv_sec_hi, tv_sec_lo, tv_nsec);
+
+        self.submitted = true;
+    }
+}
+
+pub trait ScreencopyHandler {
+    fn screencopy_state(&mut self) -> &mut ScreencopyManagerState;
+    fn frame(&mut self, screencopy: Screencopy);
+}
+
+impl ScreencopyHandler for ProjectWC {
+    fn screencopy_state(&mut self) -> &mut ScreencopyManagerState {
+        &mut self.screencopy_state
+    }
+
+    fn frame(&mut self, screencopy: Screencopy) {
+        self.pending_screencopy = Some(screencopy);
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_screencopy {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        smithay::reexports::wayland_server::delegate_global_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_manager_v1::ZwlrScreencopyManagerV1: $crate::shell::ScreencopyManagerGlobalData
+        ] => $crate::shell::ScreencopyManagerState);
+
+        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_manager_v1::ZwlrScreencopyManagerV1: ()
+        ] => $crate::shell::ScreencopyManagerState);
+
+        smithay::reexports::wayland_server::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_frame_v1::ZwlrScreencopyFrameV1: $crate::shell::ScreencopyFrameState
+        ] => $crate::shell::ScreencopyManagerState);
+    };
+}
+
+delegate_screencopy!(ProjectWC);

--- a/src/state.rs
+++ b/src/state.rs
@@ -23,6 +23,7 @@ use std::{ffi::OsString, sync::Arc};
 
 use crate::{
     layout::{GapConfig, LayoutBox, LayoutType},
+    shell::{Screencopy, ScreencopyManagerState},
     CompositorError,
 };
 
@@ -47,9 +48,11 @@ pub struct ProjectWC {
     pub popups: PopupManager,
     pub primary_selection_state: PrimarySelectionState,
     pub layer_shell_state: WlrLayerShellState,
+    pub screencopy_state: ScreencopyManagerState,
 
     pub pointer_location: Point<f64, Logical>,
     pub move_grab: Option<MoveGrab>,
+    pub pending_screencopy: Option<Screencopy>,
 }
 
 pub struct MoveGrab {
@@ -77,6 +80,7 @@ impl ProjectWC {
         let popups = PopupManager::default();
         let primary_selection_state = PrimarySelectionState::new::<Self>(&display_handle);
         let layer_shell_state = WlrLayerShellState::new::<Self>(&display_handle);
+        let screencopy_state = ScreencopyManagerState::new::<Self, _>(&display_handle, |_| true);
         let mut seat_state = SeatState::new();
 
         let mut seat = seat_state.new_wl_seat(&display_handle, "winit");
@@ -111,9 +115,11 @@ impl ProjectWC {
             popups,
             primary_selection_state,
             layer_shell_state,
+            screencopy_state,
 
             pointer_location: Point::from((0.0, 0.0)),
             move_grab: None,
+            pending_screencopy: None,
         }
     }
 


### PR DESCRIPTION
  - Add wlr-screencopy-v1 protocol support enabling grim/screenshot functionality
  - Implement screencopy frame capture with SHM buffer handling in winit backend
  - Handle screencopy after frame submit to avoid EGL context invalidation
  - Region capture (CaptureOutputRegion) not yet implemented; captures full output and relies on client-side cropping
  
  Sources:
  https://wayland.app/protocols/wlr-screencopy-unstable-v1
  https://github.com/YaLTeR/niri/blob/b5640d5293ad8dca06cb447692ea7cbb21680eb1/src/protocols/screencopy.rs#L13
  
  Before:
  
  
<img width="1288" height="832" alt="image" src="https://github.com/user-attachments/assets/37f4b4b8-c4f1-4aa6-9d75-5b2e4a6678c0" />


After:

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/fc46acde-fc16-4662-a484-c3918b72b283" />
