### PR TITLE
Udev implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,20 @@ name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bytes"
@@ -345,10 +359,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "drm"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytemuck",
+ "drm-ffi",
+ "drm-fourcc",
+ "libc",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "drm-ffi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e41459d99a9b529845f6d2c909eb9adf3b6d2f82635ae40be8de0601726e8b"
+dependencies = [
+ "drm-sys",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "drm-fourcc"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4"
+
+[[package]]
+name = "drm-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafb66c8dbc944d69e15cfcc661df7e703beffbaec8bd63151368b06c5f9858c"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.6.5",
+]
 
 [[package]]
 name = "equivalent"
@@ -404,6 +452,28 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "gbm"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce852e998d3ca5e4a97014fb31c940dc5ef344ec7d364984525fd11e8a547e6a"
+dependencies = [
+ "bitflags 2.10.0",
+ "drm",
+ "drm-fourcc",
+ "gbm-sys",
+ "libc",
+]
+
+[[package]]
+name = "gbm-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13a5f2acc785d8fb6bf6b7ab6bfb0ef5dad4f4d97e8e70bb8e470722312f76f"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "generic-array"
@@ -468,6 +538,12 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -480,6 +556,35 @@ checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "input"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdc09524a91f9cacd26f16734ff63d7dc650daffadd2b6f84d17a285bd875a9"
+dependencies = [
+ "bitflags 2.10.0",
+ "input-sys",
+ "libc",
+ "udev",
+]
+
+[[package]]
+name = "input-sys"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd4f5b4d1c00331c5245163aacfe5f20be75b564c7112d45893d4ae038119eb0"
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -564,10 +669,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "libseat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6656c69b6e0366ffb83faa232f3e4fda5fc91161722d140f2c95ce2e90b1ef31"
+dependencies = [
+ "errno",
+ "libseat-sys",
+ "log",
+]
+
+[[package]]
+name = "libseat-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a484fa48be5f62a8d3ffed767779d0ab808cfead91de98ef4362d469097dfb"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a385b1be4e5c3e362ad2ffa73c392e53f031eaa5b7d648e64cd87f27f6063d7"
 
 [[package]]
 name = "linux-raw-sys"
@@ -939,7 +1080,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
@@ -1227,16 +1368,23 @@ dependencies = [
  "atomic_float",
  "bitflags 2.10.0",
  "calloop 0.14.3",
+ "cc",
  "cgmath",
  "cursor-icon",
  "downcast-rs",
+ "drm",
+ "drm-ffi",
  "drm-fourcc",
  "errno",
+ "gbm",
  "gl_generator",
  "glow",
  "indexmap",
+ "input",
  "libc",
  "libloading",
+ "libseat",
+ "pkg-config",
  "profiling",
  "rand",
  "rustix 1.1.3",
@@ -1245,6 +1393,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tracing",
+ "udev",
  "wayland-client",
  "wayland-cursor",
  "wayland-egl",
@@ -1460,6 +1609,18 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "udev"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4e37e9ea4401fc841ff54b9ddfc9be1079b1e89434c1a6a865dd68980f7e9f"
+dependencies = [
+ "io-lifetimes",
+ "libc",
+ "libudev-sys",
+ "pkg-config",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -1755,6 +1916,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -1797,6 +1967,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -1819,6 +2004,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -1831,6 +2022,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -1840,6 +2037,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1861,6 +2064,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -1870,6 +2079,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1885,6 +2100,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -1894,6 +2115,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,12 @@ edition = "2024"
 [dependencies]
 smithay = { git = "https://github.com/Smithay/smithay/", default-features = false, features = [
   "backend_winit",
+  "backend_udev",
+  "backend_drm",
+  "backend_libinput",
+  "backend_gbm",
+  "backend_egl",
+  "backend_session_libseat",
   "desktop",
   "renderer_glow",
   "wayland_frontend",

--- a/default.nix
+++ b/default.nix
@@ -9,15 +9,29 @@
   libXcursor,
   libXrandr,
   libXi,
+  systemd,
+  libinput,
+  seatd,
+  libdrm,
+  mesa,
+  libgbm,
   gitRev ? null,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "projectwc";
-  version = if gitRev != null then lib.substring 0 8 gitRev else "dev";
+  version =
+    if gitRev != null
+    then lib.substring 0 8 gitRev
+    else "dev";
 
   src = ./.;
 
-  cargoLock.lockFile = ./Cargo.lock;
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+    outputHashes = {
+      "smithay-0.7.0" = "sha256-nLG1xqbZQ26BRTIHLPr5kK+I2J78ir4P3fUnT9vb4ek=";
+    };
+  };
 
   nativeBuildInputs = [pkg-config];
 
@@ -29,6 +43,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libXcursor
     libXrandr
     libXi
+    systemd
+    libinput
+    seatd
+    libdrm
+    mesa
+    libgbm
   ];
 
   doCheck = false;

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765779637,
-        "narHash": "sha256-KJ2wa/BLSrTqDjbfyNx70ov/HdgNBCBBSQP3BIzKnv4=",
+        "lastModified": 1767116409,
+        "narHash": "sha256-5vKw92l1GyTnjoLzEagJy5V5mDFck72LiQWZSOnSicw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1306659b587dc277866c7b69eb97e5f07864d8c4",
+        "rev": "cad22e7d996aea55ecab064e84834289143e44a0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,16 @@
 
         env = {
           RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
-          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [pkgs.wayland pkgs.libGL];
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+            pkgs.wayland
+            pkgs.libGL
+            pkgs.systemd
+            pkgs.libinput
+            pkgs.seatd
+            pkgs.libdrm
+            pkgs.mesa
+            pkgs.libgbm
+          ];
         };
       };
     });

--- a/resources/scripts/run.sh
+++ b/resources/scripts/run.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+cargo run -- --tty --debug &>/tmp/compositor.log

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,1 +1,2 @@
+pub mod udev;
 pub mod winit;

--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -1,0 +1,626 @@
+use std::{collections::HashMap, path::Path, time::Duration};
+
+use smithay::{
+    backend::{
+        allocator::{
+            format::FormatSet,
+            gbm::{GbmAllocator, GbmBufferFlags, GbmDevice},
+            Modifier,
+        },
+        drm::{
+            DrmDevice, DrmDeviceFd, DrmEvent, DrmEventMetadata, DrmNode, GbmBufferedSurface,
+            NodeType,
+        },
+        egl::{EGLContext, EGLDisplay},
+        libinput::{LibinputInputBackend, LibinputSessionInterface},
+        renderer::{
+            damage::OutputDamageTracker,
+            element::{
+                solid::{SolidColorBuffer, SolidColorRenderElement},
+                Kind,
+            },
+            gles::GlesRenderer,
+            Bind,
+        },
+        session::{libseat::LibSeatSession, Event as SessionEvent, Session},
+        udev::{UdevBackend, UdevEvent},
+    },
+    output::{Mode, Output, PhysicalProperties, Subpixel},
+    reexports::{
+        calloop::{
+            timer::{TimeoutAction, Timer},
+            LoopHandle, RegistrationToken,
+        },
+        drm::control::{self, connector, crtc, Device as ControlDevice, ModeTypeFlags},
+        input::Libinput,
+        rustix::fs::OFlags,
+    },
+    utils::{DeviceFd, Physical, Point, Rectangle, Scale, Transform},
+};
+
+use crate::{CompositorError, ProjectWC, Result};
+
+mod render_element_types {
+    use smithay::{
+        backend::renderer::{
+            element::{solid::SolidColorRenderElement, surface::WaylandSurfaceRenderElement},
+            ImportAll, Renderer,
+        },
+        render_elements,
+    };
+
+    render_elements! {
+        pub OutputRenderElements<R> where R: ImportAll;
+        Surface=WaylandSurfaceRenderElement<R>,
+        Cursor=SolidColorRenderElement,
+    }
+
+    impl<R: Renderer> std::fmt::Debug for OutputRenderElements<R> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Surface(e) => f.debug_tuple("Surface").field(e).finish(),
+                Self::Cursor(e) => f.debug_tuple("Cursor").field(e).finish(),
+                _ => f.write_str("OutputRenderElements"),
+            }
+        }
+    }
+}
+
+pub use render_element_types::OutputRenderElements;
+
+pub struct UdevData {
+    pub session: LibSeatSession,
+    pub primary_gpu: DrmNode,
+    pub devices: HashMap<DrmNode, Device>,
+}
+
+pub struct Device {
+    pub drm: DrmDevice,
+    pub drm_node: DrmNode,
+    pub gbm: GbmDevice<DrmDeviceFd>,
+    pub gles: GlesRenderer,
+    pub surfaces: HashMap<crtc::Handle, Surface>,
+    pub registration_token: RegistrationToken,
+}
+
+pub struct Surface {
+    pub output: Output,
+    pub gbm_surface: GbmBufferedSurface<GbmAllocator<DrmDeviceFd>, ()>,
+    pub damage_tracker: OutputDamageTracker,
+}
+
+pub fn init_udev(
+    event_loop: &mut smithay::reexports::calloop::EventLoop<ProjectWC>,
+    state: &mut ProjectWC,
+) -> Result<()> {
+    let (mut session, notifier) = LibSeatSession::new()
+        .map_err(|e| CompositorError::Backend(format!("failed to create session: {e:?}")))?;
+
+    let seat_name = session.seat();
+    tracing::info!("session created on seat {seat_name}");
+
+    let udev_backend = UdevBackend::new(&seat_name)
+        .map_err(|e| CompositorError::Backend(format!("failed to create udev backend: {e:?}")))?;
+
+    let primary_gpu = udev_backend
+        .device_list()
+        .filter_map(|(node, _)| {
+            DrmNode::from_dev_id(node.into())
+                .ok()?
+                .node_with_type(NodeType::Render)?
+                .ok()
+        })
+        .next()
+        .ok_or_else(|| CompositorError::Backend("no suitable GPU found".into()))?;
+
+    tracing::info!("using primary GPU: {primary_gpu}");
+
+    let udev_data = UdevData {
+        session: session.clone(),
+        primary_gpu,
+        devices: HashMap::new(),
+    };
+
+    state.udev = Some(udev_data);
+
+    for (device_id, path) in udev_backend.device_list() {
+        if let Err(e) = add_device(state, &mut session, device_id.into(), &path) {
+            tracing::warn!("failed to add device {path:?}: {e:?}");
+        }
+    }
+
+    let mut libinput_context =
+        Libinput::new_with_udev::<LibinputSessionInterface<LibSeatSession>>(session.clone().into());
+
+    libinput_context
+        .udev_assign_seat(&seat_name)
+        .map_err(|_| CompositorError::Backend("failed to assign seat to libinput".into()))?;
+
+    tracing::info!("libinput initialized on seat {seat_name}");
+
+    let libinput_backend = LibinputInputBackend::new(libinput_context.clone());
+
+    event_loop
+        .handle()
+        .insert_source(libinput_backend, |event, _, state| {
+            state.handle_input_event(event);
+        })
+        .map_err(|e| CompositorError::Backend(format!("failed to insert libinput: {e:?}")))?;
+
+    event_loop
+        .handle()
+        .insert_source(notifier, |event, _, state| match event {
+            SessionEvent::PauseSession => {
+                tracing::info!("session paused");
+                if let Some(udev) = &mut state.udev {
+                    for device in udev.devices.values_mut() {
+                        device.drm.pause();
+                    }
+                }
+            }
+            SessionEvent::ActivateSession => {
+                tracing::info!("session activated");
+                if let Some(udev) = &mut state.udev {
+                    for device in udev.devices.values_mut() {
+                        device.drm.activate(false).ok();
+                        for surface in device.surfaces.values_mut() {
+                            surface.gbm_surface.reset_buffers();
+                        }
+                    }
+                }
+            }
+        })
+        .map_err(|e| {
+            CompositorError::Backend(format!("failed to insert session notifier: {e:?}"))
+        })?;
+
+    event_loop
+        .handle()
+        .insert_source(udev_backend, |event, _, state| match event {
+            UdevEvent::Added { device_id, path } => {
+                if let Some(udev) = &mut state.udev {
+                    let mut session = udev.session.clone();
+                    if let Err(e) = add_device(state, &mut session, device_id.into(), &path) {
+                        tracing::warn!("failed to add device {path:?}: {e:?}");
+                    }
+                }
+            }
+            UdevEvent::Changed { device_id } => {
+                tracing::info!("device changed: {device_id}");
+            }
+            UdevEvent::Removed { device_id } => {
+                if let Ok(node) = DrmNode::from_dev_id(device_id.into()) {
+                    remove_device(state, node);
+                }
+            }
+        })
+        .map_err(|e| CompositorError::Backend(format!("failed to insert udev: {e:?}")))?;
+
+    unsafe { std::env::set_var("WAYLAND_DISPLAY", &state.socket_name) };
+
+    schedule_initial_render(&state.loop_handle);
+
+    Ok(())
+}
+
+fn add_device(
+    state: &mut ProjectWC,
+    session: &mut LibSeatSession,
+    device_id: u64,
+    path: &Path,
+) -> Result<()> {
+    let node = DrmNode::from_dev_id(device_id)
+        .map_err(|e| CompositorError::Backend(format!("failed to get DRM node: {e:?}")))?;
+
+    let fd = session
+        .open(path, OFlags::RDWR | OFlags::CLOEXEC)
+        .map_err(|e| CompositorError::Backend(format!("failed to open device: {e:?}")))?;
+
+    let device_fd = DrmDeviceFd::new(DeviceFd::from(fd));
+
+    let (drm, drm_notifier) = DrmDevice::new(device_fd.clone(), true)
+        .map_err(|e| CompositorError::Backend(format!("failed to create DRM device: {e:?}")))?;
+
+    let gbm = GbmDevice::new(device_fd.clone())
+        .map_err(|e| CompositorError::Backend(format!("failed to create GBM device: {e:?}")))?;
+
+    let egl_display = unsafe { EGLDisplay::new(gbm.clone()) }
+        .map_err(|e| CompositorError::Backend(format!("failed to create EGL display: {e:?}")))?;
+
+    let egl_context = EGLContext::new(&egl_display)
+        .map_err(|e| CompositorError::Backend(format!("failed to create EGL context: {e:?}")))?;
+
+    let gles = unsafe { GlesRenderer::new(egl_context) }
+        .map_err(|e| CompositorError::Backend(format!("failed to create GLES renderer: {e:?}")))?;
+
+    let registration_token = state
+        .loop_handle
+        .insert_source(drm_notifier, move |event, metadata, state| {
+            handle_drm_event(state, node, event, metadata);
+        })
+        .map_err(|e| CompositorError::Backend(format!("failed to insert DRM notifier: {e:?}")))?;
+
+    let device = Device {
+        drm,
+        drm_node: node,
+        gbm,
+        gles,
+        surfaces: HashMap::new(),
+        registration_token,
+    };
+
+    let udev = state
+        .udev
+        .as_mut()
+        .ok_or_else(|| CompositorError::Backend("udev data not initialized".into()))?;
+
+    udev.devices.insert(node, device);
+
+    scan_connectors(state, node)?;
+
+    Ok(())
+}
+
+fn remove_device(state: &mut ProjectWC, node: DrmNode) {
+    let Some(udev) = &mut state.udev else { return };
+
+    if let Some(device) = udev.devices.remove(&node) {
+        for (_, surface) in device.surfaces {
+            state.space.unmap_output(&surface.output);
+        }
+        state.loop_handle.remove(device.registration_token);
+    }
+}
+
+fn scan_connectors(state: &mut ProjectWC, node: DrmNode) -> Result<()> {
+    let udev = state
+        .udev
+        .as_mut()
+        .ok_or_else(|| CompositorError::Backend("udev data not initialized".into()))?;
+
+    let device = udev
+        .devices
+        .get_mut(&node)
+        .ok_or_else(|| CompositorError::Backend("device not found".into()))?;
+
+    let res_handles = device
+        .drm
+        .resource_handles()
+        .map_err(|e| CompositorError::Backend(format!("failed to get resource handles: {e:?}")))?;
+
+    let connectors: Vec<_> = res_handles.connectors().iter().copied().collect();
+
+    for connector in connectors {
+        let connector_info = device.drm.get_connector(connector, true).map_err(|e| {
+            CompositorError::Backend(format!("failed to get connector info: {e:?}"))
+        })?;
+
+        if connector_info.state() != connector::State::Connected {
+            continue;
+        }
+
+        let modes = connector_info.modes();
+        let drm_mode = modes
+            .iter()
+            .find(|m| m.mode_type().contains(ModeTypeFlags::PREFERRED))
+            .or_else(|| modes.first())
+            .copied()
+            .ok_or_else(|| CompositorError::Backend("no mode found for connector".into()))?;
+
+        let crtc = find_crtc_for_connector(device, &res_handles, connector)?;
+
+        let physical_properties = PhysicalProperties {
+            size: connector_info
+                .size()
+                .map(|(w, h)| (w as i32, h as i32))
+                .unwrap_or((0, 0))
+                .into(),
+            subpixel: Subpixel::Unknown,
+            make: "projectwc".into(),
+            model: format!("{:?}", connector_info.interface()),
+            serial_number: "Unknown".into(),
+        };
+
+        let output = Output::new(
+            format!(
+                "{}-{}",
+                connector_info.interface().as_str(),
+                connector_info.interface_id()
+            ),
+            physical_properties,
+        );
+
+        let smithay_mode = Mode {
+            size: (drm_mode.size().0 as i32, drm_mode.size().1 as i32).into(),
+            refresh: (drm_mode.vrefresh() * 1000) as i32,
+        };
+
+        output.create_global::<ProjectWC>(&state.display_handle);
+        output.change_current_state(Some(smithay_mode), Some(Transform::Normal), None, None);
+        output.set_preferred(smithay_mode);
+
+        let drm_surface = device
+            .drm
+            .create_surface(crtc, drm_mode, &[connector])
+            .map_err(|e| {
+                CompositorError::Backend(format!("failed to create DRM surface: {e:?}"))
+            })?;
+
+        let allocator = GbmAllocator::new(
+            device.gbm.clone(),
+            GbmBufferFlags::RENDERING | GbmBufferFlags::SCANOUT,
+        );
+
+        let renderer_formats = device.gles.egl_context().dmabuf_render_formats().clone();
+
+        let filtered_formats: Vec<_> = renderer_formats
+            .iter()
+            .copied()
+            .filter(|format| {
+                !matches!(
+                    format.modifier,
+                    Modifier::I915_y_tiled_ccs
+                        | Modifier::I915_y_tiled_gen12_rc_ccs
+                        | Modifier::I915_y_tiled_gen12_mc_ccs
+                )
+            })
+            .collect();
+
+        tracing::debug!(
+            "filtered {} CCS formats, {} remaining",
+            renderer_formats.iter().count() - filtered_formats.len(),
+            filtered_formats.len()
+        );
+
+        let format_codes: Vec<_> = filtered_formats.iter().map(|f| f.code).collect();
+        let filtered_set: FormatSet = filtered_formats.iter().copied().collect();
+
+        let gbm_surface = match GbmBufferedSurface::new(
+            drm_surface,
+            allocator.clone(),
+            &format_codes,
+            filtered_set.clone(),
+        ) {
+            Ok(surface) => surface,
+            Err(e) => {
+                tracing::warn!(
+                    "GBM surface creation failed, retrying with implicit modifier: {e:?}"
+                );
+                let implicit_formats: Vec<_> = filtered_formats
+                    .iter()
+                    .copied()
+                    .filter(|f| f.modifier == Modifier::Invalid)
+                    .collect();
+                let implicit_codes: Vec<_> = implicit_formats.iter().map(|f| f.code).collect();
+                let implicit_set: FormatSet = implicit_formats.iter().copied().collect();
+
+                let drm_surface2 = device
+                    .drm
+                    .create_surface(crtc, drm_mode, &[connector])
+                    .map_err(|e| {
+                        CompositorError::Backend(format!("failed to create DRM surface: {e:?}"))
+                    })?;
+
+                GbmBufferedSurface::new(drm_surface2, allocator, &implicit_codes, implicit_set)
+                    .map_err(|e| {
+                        CompositorError::Backend(format!(
+                            "failed to create GBM surface with implicit modifier: {e:?}"
+                        ))
+                    })?
+            }
+        };
+
+        let damage_tracker = OutputDamageTracker::from_output(&output);
+
+        let surface = Surface {
+            output: output.clone(),
+            gbm_surface,
+            damage_tracker,
+        };
+
+        device.surfaces.insert(crtc, surface);
+        state.space.map_output(&output, (0, 0));
+
+        tracing::info!(
+            "output {} enabled: {}x{}@{}Hz",
+            output.name(),
+            drm_mode.size().0,
+            drm_mode.size().1,
+            drm_mode.vrefresh()
+        );
+    }
+
+    Ok(())
+}
+
+fn find_crtc_for_connector(
+    device: &Device,
+    res_handles: &control::ResourceHandles,
+    connector: connector::Handle,
+) -> Result<crtc::Handle> {
+    let connector_info = device
+        .drm
+        .get_connector(connector, false)
+        .map_err(|e| CompositorError::Backend(format!("failed to get connector info: {e:?}")))?;
+
+    let encoder = connector_info
+        .current_encoder()
+        .and_then(|e| device.drm.get_encoder(e).ok())
+        .or_else(|| {
+            connector_info
+                .encoders()
+                .iter()
+                .filter_map(|e| device.drm.get_encoder(*e).ok())
+                .next()
+        })
+        .ok_or_else(|| CompositorError::Backend("no encoder found".into()))?;
+
+    let crtcs: Vec<_> = res_handles.crtcs().iter().copied().collect();
+    let possible = encoder.possible_crtcs();
+
+    for crtc in crtcs {
+        if res_handles.filter_crtcs(possible).contains(&crtc)
+            && !device.surfaces.contains_key(&crtc)
+        {
+            return Ok(crtc);
+        }
+    }
+
+    Err(CompositorError::Backend("no available CRTC found".into()))
+}
+
+fn handle_drm_event(
+    state: &mut ProjectWC,
+    node: DrmNode,
+    event: DrmEvent,
+    _metadata: &mut Option<DrmEventMetadata>,
+) {
+    match event {
+        DrmEvent::VBlank(crtc) => {
+            if let Some(udev) = &mut state.udev {
+                if let Some(device) = udev.devices.get_mut(&node) {
+                    if let Some(surface) = device.surfaces.get_mut(&crtc) {
+                        surface.gbm_surface.frame_submitted().ok();
+                    }
+                }
+            }
+            schedule_render(&state.loop_handle);
+        }
+        DrmEvent::Error(e) => {
+            tracing::error!("DRM error: {e:?}");
+        }
+    }
+}
+
+fn schedule_initial_render(loop_handle: &LoopHandle<'static, ProjectWC>) {
+    let timer = Timer::immediate();
+    loop_handle
+        .insert_source(timer, |_, _, state| {
+            render(state);
+            TimeoutAction::Drop
+        })
+        .ok();
+}
+
+fn schedule_render(loop_handle: &LoopHandle<'static, ProjectWC>) {
+    let timer = Timer::immediate();
+    loop_handle
+        .insert_source(timer, |_, _, state| {
+            render(state);
+            TimeoutAction::Drop
+        })
+        .ok();
+}
+
+fn render(state: &mut ProjectWC) {
+    let Some(udev) = &mut state.udev else {
+        tracing::warn!("render: no udev data");
+        return;
+    };
+
+    if udev.devices.is_empty() {
+        tracing::warn!("render: no devices");
+        return;
+    }
+
+    for device in udev.devices.values_mut() {
+        if device.surfaces.is_empty() {
+            tracing::warn!("render: no surfaces on device");
+            continue;
+        }
+
+        for (_crtc, surface) in &mut device.surfaces {
+            let output = surface.output.clone();
+
+            let (mut dmabuf, _age) = match surface.gbm_surface.next_buffer() {
+                Ok(result) => result,
+                Err(e) => {
+                    tracing::warn!("failed to get next buffer: {e:?}");
+                    continue;
+                }
+            };
+
+            let mut framebuffer = match device.gles.bind(&mut dmabuf) {
+                Ok(fb) => fb,
+                Err(e) => {
+                    tracing::warn!("failed to bind dmabuf: {e:?}");
+                    continue;
+                }
+            };
+
+            let output_size = output
+                .current_mode()
+                .map(|m| m.size)
+                .unwrap_or((1920, 1080).into());
+
+            let damage = Rectangle::from_size(output_size);
+
+            let cursor_size = 16;
+            let cursor_buffer =
+                SolidColorBuffer::new((cursor_size, cursor_size), [1.0, 1.0, 1.0, 1.0]);
+            let cursor_pos: Point<i32, Physical> = (
+                state.pointer_location.x as i32,
+                state.pointer_location.y as i32,
+            )
+                .into();
+            let cursor_element = SolidColorRenderElement::from_buffer(
+                &cursor_buffer,
+                cursor_pos,
+                Scale::from(1.0),
+                1.0,
+                Kind::Cursor,
+            );
+
+            let custom_elements: Vec<OutputRenderElements<GlesRenderer>> =
+                vec![OutputRenderElements::Cursor(cursor_element)];
+
+            let render_result = smithay::desktop::space::render_output::<
+                _,
+                OutputRenderElements<GlesRenderer>,
+                _,
+                _,
+            >(
+                &output,
+                &mut device.gles,
+                &mut framebuffer,
+                1.0,
+                0,
+                [&state.space],
+                &custom_elements,
+                &mut surface.damage_tracker,
+                [0.1, 0.1, 0.1, 1.0],
+            );
+
+            match render_result {
+                Ok(_) => {
+                    match surface
+                        .gbm_surface
+                        .queue_buffer(None, Some(vec![damage]), ())
+                    {
+                        Ok(_) => {
+                            tracing::debug!("frame queued for {}", output.name());
+                        }
+                        Err(e) => {
+                            tracing::warn!("failed to queue buffer: {e:?}");
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("render failed: {e:?}");
+                }
+            }
+
+            state.space.elements().for_each(|window| {
+                window.send_frame(
+                    &output,
+                    state.start_time.elapsed(),
+                    Some(Duration::ZERO),
+                    |_, _| Some(output.clone()),
+                );
+            });
+        }
+    }
+
+    state.space.refresh();
+    state.display_handle.flush_clients().ok();
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -88,7 +88,11 @@ impl ProjectWC {
     }
 
     fn handle_pointer_motion<B: InputBackend>(&mut self, event: B::PointerMotionEvent) {
-        tracing::debug!("pointer motion: pos=({:.0}, {:.0})", self.pointer_location.x, self.pointer_location.y);
+        tracing::debug!(
+            "pointer motion: pos=({:.0}, {:.0})",
+            self.pointer_location.x,
+            self.pointer_location.y
+        );
         let serial = SERIAL_COUNTER.next_serial();
         let delta = (event.delta_x(), event.delta_y()).into();
 
@@ -203,7 +207,9 @@ impl ProjectWC {
             .map(|(w, l)| (w.clone(), l));
         tracing::info!(
             "element_under: {:?}",
-            element_under.as_ref().map(|(w, l)| (w.toplevel().map(|t| t.wl_surface().id()), l))
+            element_under
+                .as_ref()
+                .map(|(w, l)| (w.toplevel().map(|t| t.wl_surface().id()), l))
         );
 
         if ButtonState::Pressed == button_state

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,16 @@
-use projectwc::{CompositorError, Result, state::ProjectWC};
+use projectwc::{state::ProjectWC, CompositorError, Result};
 use smithay::reexports::{calloop::EventLoop, wayland_server::Display};
 
 fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+
+    let use_udev = args.iter().any(|a| a == "--tty" || a == "--udev");
+    let debug = args.iter().any(|a| a == "--debug");
+
+    if debug {
+        unsafe { std::env::set_var("RUST_LOG", "debug") };
+    }
+
     if let Ok(env_filter) = tracing_subscriber::EnvFilter::try_from_default_env() {
         tracing_subscriber::fmt().with_env_filter(env_filter).init();
     } else {
@@ -14,11 +23,23 @@ fn main() -> Result<()> {
     let display = Display::new().map_err(|e| CompositorError::Backend(e.to_string()))?;
     let mut state = ProjectWC::new(display, event_loop.handle(), event_loop.get_signal());
 
-    projectwc::backend::winit::init_winit(&mut event_loop, &mut state)?;
+    let use_udev = use_udev
+        || std::env::var("PROJECTWC_BACKEND")
+            .map(|v| v == "udev")
+            .unwrap_or(false)
+        || (std::env::var("WAYLAND_DISPLAY").is_err() && std::env::var("DISPLAY").is_err());
 
-    let spawn_cmd: Option<String> = std::env::args().nth(1);
+    if use_udev {
+        tracing::info!("using udev backend");
+        projectwc::backend::udev::init_udev(&mut event_loop, &mut state)?;
+    } else {
+        tracing::info!("using winit backend");
+        projectwc::backend::winit::init_winit(&mut event_loop, &mut state)?;
+    }
+
+    let spawn_cmd = args.iter().find(|a| !a.starts_with('-') && *a != &args[0]);
     if let Some(cmd) = spawn_cmd {
-        std::process::Command::new(&cmd).spawn().ok();
+        std::process::Command::new(cmd).spawn().ok();
     }
 
     event_loop

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,12 +1,12 @@
 use smithay::{
     desktop::{PopupManager, Space, Window, WindowSurfaceType},
-    input::{Seat, SeatState, pointer::PointerHandle},
+    input::{pointer::PointerHandle, Seat, SeatState},
     reexports::{
-        calloop::{Interest, LoopHandle, LoopSignal, Mode, PostAction, generic::Generic},
+        calloop::{generic::Generic, Interest, LoopHandle, LoopSignal, Mode, PostAction},
         wayland_server::{
-            Display, DisplayHandle,
             backend::{ClientData, ClientId, DisconnectReason},
             protocol::wl_surface::WlSurface,
+            Display, DisplayHandle,
         },
     },
     utils::{Logical, Point},
@@ -22,9 +22,10 @@ use smithay::{
 use std::{ffi::OsString, sync::Arc};
 
 use crate::{
-    CompositorError,
+    backend::udev::UdevData,
     layout::{GapConfig, LayoutBox, LayoutType},
     protocols::wlr_screencopy::{Screencopy, ScreencopyManagerState},
+    CompositorError,
 };
 
 pub struct ProjectWC {
@@ -53,6 +54,7 @@ pub struct ProjectWC {
     pub pointer_location: Point<f64, Logical>,
     pub move_grab: Option<MoveGrab>,
     pub pending_screencopy: Option<Screencopy>,
+    pub udev: Option<UdevData>,
 }
 
 pub struct MoveGrab {
@@ -120,6 +122,7 @@ impl ProjectWC {
             pointer_location: Point::from((0.0, 0.0)),
             move_grab: None,
             pending_screencopy: None,
+            udev: None,
         }
     }
 


### PR DESCRIPTION
- implemented udev backend with libseat session management, drm/gbm rendering, and libinput for real hardware input
- fixed intel gpu issues by filtering ccs modifiers (referenced niri's tty backend)
- added software cursor rendering since drm mode requires drawing our own cursor
- supports --tty flag to force udev backend, auto-detects when no wayland/x11 display is available


put script in `resources/scripts` called `run.sh` to test it from the tty.